### PR TITLE
2.0.2

### DIFF
--- a/User Registration Prompt.zsh
+++ b/User Registration Prompt.zsh
@@ -21,6 +21,9 @@
 #   - Changed script to zsh for array use with dialog
 #   - Added personalized salutation based on computer's current time
 #
+#  Version 2.0.2, 02.21.2024, Ben Whitis (@benwhitis)
+#  - Addressed an issue where some computers were experiencing errors during the swift dialog check process, resulting in a `= not found` in the logs (Issue #2)
+#
 ####################################################################################################
 
 ####################################################################################################

--- a/User Registration Prompt.zsh
+++ b/User Registration Prompt.zsh
@@ -36,7 +36,7 @@
 # Script Version and Jamf Pro Script Parameters
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-scriptVersion="2.0.1"
+scriptVersion="2.0.2"
 scriptFunctionalName="AAD User Registration Prompt"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 


### PR DESCRIPTION
- Addressed an issue where some computers were experiencing errors during the swift dialog check process, resulting in a `= not found` in the logs (Issue #2)